### PR TITLE
Update specification files for RHEL8

### DIFF
--- a/SPECS/berkeleydb-ltb.spec
+++ b/SPECS/berkeleydb-ltb.spec
@@ -4,8 +4,9 @@
 # Install BerkeleyDB
 # Modify /etc/ld.so.conf
 #
+# Copyright (C) 2008-2019 Clement OUDOT
+# Copyright (C) 2018-2019 Worteks
 # Copyright (C) 2008 Raphael Ouazana
-# Copyright (C) 2008 Clement OUDOT
 # Copyright (C) 2008 LINAGORA
 #
 # LTB project (http://www.ltb-project.org)
@@ -42,7 +43,7 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 
 BuildRequires: gcc, make
 
-Prereq: /sbin/ldconfig, coreutils
+Requires(pre): /sbin/ldconfig, coreutils
 
 %description
 Berkeley DB, the most widely-used developer database in the world, is open

--- a/SPECS/berkeleydb-ltb.spec
+++ b/SPECS/berkeleydb-ltb.spec
@@ -71,7 +71,7 @@ of a query processing layer.
 %build
 cd build_unix
 export CC=gcc
-../dist/configure --prefix=%{bdbdir} --libdir=%{bdbdir}/%{_lib}
+../dist/configure --prefix=%{bdbdir} --libdir=%{bdbdir}/%{_lib} --enable--debug
 make %{?_smp_mflags}
 
 #=================================================

--- a/SPECS/berkeleydb-ltb.spec
+++ b/SPECS/berkeleydb-ltb.spec
@@ -71,7 +71,7 @@ of a query processing layer.
 %build
 cd build_unix
 export CC=gcc
-../dist/configure --prefix=%{bdbdir} --libdir=%{bdbdir}/%{_lib} --enable--debug
+../dist/configure --prefix=%{bdbdir} --libdir=%{bdbdir}/%{_lib} --enable-debug
 make %{?_smp_mflags}
 
 #=================================================

--- a/SPECS/openldap-ltb.spec
+++ b/SPECS/openldap-ltb.spec
@@ -251,12 +251,21 @@ make depend
 make %{?_smp_mflags}
 # check_password
 cd %{check_password_name}-%{check_password_version}
+%if "%{?dist}" == ".el8"
+sed -i 's:^CRACKLIB_LIB:#CRACKLIB_LIB:' Makefile
+make %{?_smp_mflags} "CONFIG=%{check_password_conf}" "LDAP_INC=-I../include -I../servers/slapd" 'OPT=-g -O2 -Wall -fpic -DDEBUG -DCONFIG_FILE="\"$(CONFIG)\""'
+%else
 make %{?_smp_mflags} "CONFIG=%{check_password_conf}" "LDAP_INC=-I../include -I../servers/slapd"
+%endif
 cd ..
 # ppm
 cd %{ppm_name}-%{ppm_version}
 make clean
+%if "%{?dist}" == ".el8"
+make "CONFIG=%{ppm_conf}" "OLDAP_SOURCES=.." "CRACK_INC=" "CRACK_LIB="
+%else
 make "CONFIG=%{ppm_conf}" "OLDAP_SOURCES=.."
+%endif
 cd ..
 # contrib-overlays
 cd contrib/slapd-modules
@@ -363,7 +372,11 @@ echo "minPunct %{check_password_minPunct}" >> %{buildroot}%{check_password_conf}
 
 # ppm
 cd %{ppm_name}-%{ppm_version}
+%if "%{?dist}" == ".el8"
+make install "CONFIG=%{buildroot}%{ppm_conf}" LIBDIR="%{buildroot}%{ldapserverdir}/%{_lib}" "CRACK_INC=" "CRACK_LIB="
+%else
 make install "CONFIG=%{buildroot}%{ppm_conf}" LIBDIR="%{buildroot}%{ldapserverdir}/%{_lib}"
+%endif
 cd ..
 
 # contrib-overlays

--- a/SPECS/openldap-ltb.spec
+++ b/SPECS/openldap-ltb.spec
@@ -23,9 +23,15 @@
 %define real_name        openldap
 %define real_version     2.4.47
 %define release_version  1%{?dist}
+
 # Fix for CentOS7
 %if 0%{?rhel} == 7
  %define dist .el7
+%endif
+
+# Fix for CentOS8
+%if 0%{?rhel} == 8
+ %define dist .el8
 %endif
 
 %define bdbdir           /usr/local/berkeleydb
@@ -92,7 +98,7 @@ BuildRequires: openssl-devel, cyrus-sasl-devel, berkeleydb-ltb >= 4.6.21, libtoo
 BuildRequires: cracklib
 BuildRequires: tcp_wrappers-devel
 
-%if "%{?dist}" == ".el7"
+%if "%{?dist}" == ".el7" || "%{?dist}" == ".el8"
 %{?systemd_requires}
 BuildRequires: systemd
 %endif
@@ -125,10 +131,7 @@ Release:        8%{?dist}
 Group:          Applications/System
 URL:		http://www.ltb-project.org
 
-%if "%{?dist}" == ".el6"
-BuildRequires:	cracklib-devel
-%endif
-%if "%{?dist}" == ".el7"
+%if "%{?dist}" == ".el6" || "%{?dist}" == ".el7"
 BuildRequires:	cracklib-devel
 %endif
 
@@ -309,7 +312,7 @@ mkdir -p %{buildroot}%{ldaplogsdir}
 mkdir -p %{buildroot}%{ldapbackupdir}
 
 # Init script
-%if "%{?dist}" == ".el7"
+%if "%{?dist}" == ".el7" || "%{?dist}" == ".el8"
 mkdir -p %{buildroot}%{_unitdir}/
 install -m 644 %{slapd_init_name}-%{slapd_init_version}/slapd.service %{buildroot}%{_unitdir}/
 %else
@@ -421,7 +424,7 @@ fi
 # If upgrade stop slapd
 if [ $1 -eq 2 ]
 then
-%if "%{?dist}" == ".el7"
+%if "%{?dist}" == ".el7" || "%{?dist}" == ".el8"
 	/bin/systemctl stop slapd.service
 %else
 	/sbin/service slapd stop > /dev/null 2>&1
@@ -433,7 +436,7 @@ fi
 # Post Installation
 #=================================================
 
-%if "%{?dist}" == ".el7"
+%if "%{?dist}" == ".el7" || "%{?dist}" == ".el8"
 %systemd_post slapd.service
 /bin/systemctl --system daemon-reload
 %endif
@@ -504,7 +507,7 @@ getent passwd %{ldapuser} >/dev/null || useradd -r -g %{ldapgroup} -u 55 -d %{ld
 # Pre Uninstallation
 #=================================================
 
-%if "%{?dist}" == ".el7"
+%if "%{?dist}" == ".el7" || "%{?dist}" == ".el8"
 %systemd_preun slapd.service
 %endif
 
@@ -542,7 +545,7 @@ sed -i '\:'%{ldapserverdir}/%{_lib}':d' /etc/ld.so.conf
 if [ -e %{_localstatedir}/openldap-ltb-slapd-running ]
 then
 	# Start slapd
-%if "%{?dist}" == ".el7"
+%if "%{?dist}" == ".el7" || "%{?dist}" == ".el8"
 	/bin/systemctl start slapd.service
 %else
 	/sbin/service slapd start > /dev/null 2>&1
@@ -572,7 +575,7 @@ rm -rf %{buildroot}
 %docdir %{ldapserverdir}/share/man
 %config(noreplace) %{ldapserverdir}/etc/openldap/slapd.conf
 %config(noreplace) %{ldapserverdir}/etc/openldap/ldap.conf
-%if "%{?dist}" == ".el7"
+%if "%{?dist}" == ".el7" || "%{?dist}" == ".el8"
 %{_unitdir}/slapd.service
 %else
 /etc/init.d/slapd

--- a/SPECS/openldap-ltb.spec
+++ b/SPECS/openldap-ltb.spec
@@ -7,9 +7,10 @@
 # Configure syslog and logrotate
 # Install a pwdChecker module
 #
+# Copyright (C) 2008-2019 Clement OUDOT
+# Copyright (C) 2018-2019 Worteks
 # Copyright (C) 2015 David COUTADEUR
 # Copyright (C) 2008 Raphael OUAZANA
-# Copyright (C) 2015 Clement OUDOT
 # Copyright (C) 2015 LINAGORA
 # Copyright (C) 2015 Savoir-faire Linux
 #

--- a/SPECS/openldap-ltb.spec
+++ b/SPECS/openldap-ltb.spec
@@ -93,10 +93,13 @@ Source6: %{ppm_name}-%{ppm_version}.tar.gz
 Source7: %{explockout_name}-%{explockout_version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
-BuildRequires: gcc, make, groff
+BuildRequires: gcc, make
 BuildRequires: openssl-devel, cyrus-sasl-devel, berkeleydb-ltb >= 4.6.21, libtool-ltdl-devel
 BuildRequires: cracklib
-BuildRequires: tcp_wrappers-devel
+
+%if "%{?dist}" != ".el8"
+BuildRequires: groff, tcp_wrappers-devel
+%endif
 
 %if "%{?dist}" == ".el7" || "%{?dist}" == ".el8"
 %{?systemd_requires}
@@ -239,7 +242,11 @@ export CFLAGS="-DOPENLDAP_FD_SETSIZE=4096 -O2 -g -DSLAP_SCHEMA_EXPOSE"
 #export CFLAGS="-DOPENLDAP_FD_SETSIZE=4096 -O2 -g -DSLAP_SCHEMA_EXPOSE -DSLAP_CONFIG_DELETE"
 export CPPFLAGS="-I%{bdbdir}/include -I/usr/kerberos/include"
 export LDFLAGS="-L%{bdbdir}/%{_lib}"
+%if "%{?dist}" == ".el8"
+./configure --disable-dependency-tracking --enable-ldap --enable-debug --prefix=%{ldapserverdir} --libdir=%{ldapserverdir}/%{_lib} --with-tls --with-cyrus-sasl --enable-spasswd --enable-overlays --enable-modules --enable-dynamic=no --enable-slapi --enable-meta --enable-crypt --enable-sock --enable-rlookups
+%else
 ./configure --disable-dependency-tracking --enable-ldap --enable-debug --prefix=%{ldapserverdir} --libdir=%{ldapserverdir}/%{_lib} --with-tls --with-cyrus-sasl --enable-spasswd --enable-overlays --enable-modules --enable-dynamic=no --enable-slapi --enable-meta --enable-crypt --enable-sock --enable-wrappers --enable-rlookups
+%endif
 make depend
 make %{?_smp_mflags}
 # check_password


### PR DESCRIPTION
RHEL8 does not provides the following packages:
* groff
* tcp_wrappers-devel
* cracklib-devel

So specification files have been updated to compile BerkeleyDB and OpenLDAP on RHEL8.