### PR TITLE
Change default ldapi:/// path to /var/run/slapd/ldapi

### DIFF
--- a/SOURCES/change_default_ldapi_path.diff
+++ b/SOURCES/change_default_ldapi_path.diff
@@ -1,0 +1,12 @@
+--- a/include/ldap_defaults.h
++++ b/include/ldap_defaults.h
+@@ -39,7 +39,7 @@
+ #define LDAP_ENV_PREFIX "LDAP"
+
+ /* default ldapi:// socket */
+-#define LDAPI_SOCK LDAP_RUNDIR LDAP_DIRSEP "run" LDAP_DIRSEP "ldapi"
++#define LDAPI_SOCK "/var/run/slapd/ldapi"
+
+ /*
+  * SLAPD DEFINITIONS
+

--- a/SPECS/openldap-ltb.spec
+++ b/SPECS/openldap-ltb.spec
@@ -91,6 +91,8 @@ Source5: openldap.logrotate
 Source6: %{ppm_name}-%{ppm_version}.tar.gz
 # Sources available on https://github.com/davidcoutadeur/explockout
 Source7: %{explockout_name}-%{explockout_version}.tar.gz
+# This patch changes the default ldapi:/// path to /var/run/slapd/ldapi
+Patch0: change_default_ldapi_path.diff
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires: gcc, make
@@ -230,6 +232,9 @@ exponential time
 %setup -n %{real_name}-%{real_version} -T -D -a 2
 %setup -n %{real_name}-%{real_version} -T -D -a 6
 %setup -n %{real_name}-%{real_version} -T -D -a 7
+
+# Apply patches
+%patch0 -p1
 
 #=================================================
 # Building


### PR DESCRIPTION
Having to specify a weird URL whenever you run ldapsearch or ldapvi is a bit of a pain ;)